### PR TITLE
Bootstrap Flux with Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,10 @@ go.work.sum
 
 # env file
 .env
+
+# Terraform
+**/.terraform
+*.tfstate
+*.tfstate.*
+.terraform.lock.hcl
+.terraformrc

--- a/README.md
+++ b/README.md
@@ -26,28 +26,124 @@ and **cluster admin** rights to all clusters in the fleet to be able to perform 
 
 ## OCI Artifacts
 
-The content of this repository is packaged as an OCI Artifact, signed and published to GitHub Container Registry
-using the [push-artifact](https://github.com/controlplaneio-fluxcd/d2-fleet/blob/main/.github/workflows/push-artifact.yaml)
-GitHub Actions workflow.
+The content of the D2 repositories are packaged as OCI Artifacts and published
+to GitHub Container Registry using GitHub Actions workflows defined in each repository.
+The artifacts are signed with the Cosign keyless procedure using the GitHub Actions OIDC.
+
+Flux running in the clusters, pulls the OCI Artifacts to reconcile the desired state and
+verifies the integrity of the content using the Cosign signature. On production clusters,
+the artifacts signature subject must match the GitHub repository, Git tag and the
+GitHub workflow used to publish the artifact.
+
+### Fleet Artifacts
+
+The artifacts published to `oci://ghcr.io/controlplaneio-fluxcd/d2-fleet` are tagged as:
+
+- `main-<commit-short-sha>` for the main branch commits.
+- `latest` points to the latest artifact tagged as `main-<commit-short-sha>`.
+- `vX.Y.Z` for the release tags.
+- `latest-stable` points to the latest artifact tagged as `vX.Y.Z`.
 
 The Flux Operator running on the Kubernetes clusters in the fleet is configured with a
 [FluxInstance](https://github.com/controlplaneio-fluxcd/d2-fleet/blob/main/clusters/staging/flux-system/flux-instance.yaml)
-pointing to the OCI Artifact that defines the desired state of each cluster.
+pointing to the OCI Artifact that defines the desired state of each cluster. The staging clusters
+are synced from the `latest` tag, while the production clusters are synced from the `latest-stable` tag.
+
+### Components Artifacts
 
 The infrastructure components from `d2-infra` and the applications from `d2-apps` follow the same pattern
 and are packaged as OCI Artifacts. The delivery of these components is performed by the Flux Operator
 using the [ResourceSet](https://github.com/controlplaneio-fluxcd/d2-fleet/tree/main/tenants) definitions.
 
+Each component is published to a dedicated OCI repository, for example, the `frontend` component
+is published to `oci://ghcr.io/controlplaneio-fluxcd/d2-apps/frontend` and is tagged as:
 
-| Artifact                                                    | Git Repository | Envs                                                       |
-|-------------------------------------------------------------|----------------|------------------------------------------------------------|
-| `oci://ghcr.io/controlplaneio-fluxcd/d2-fleet`              | d2-fleet       | staging / production / GHA image update automation cluster |
-| `oci://ghcr.io/controlplaneio-fluxcd/d2-infra/cert-manager` | d2-infra       | staging / production                                       |
-| `oci://ghcr.io/controlplaneio-fluxcd/d2-infra/monitoring`   | d2-infra       | staging / production                                       |
-| `oci://ghcr.io/controlplaneio-fluxcd/d2-apps/backend`       | d2-apps        | staging / production                                       |
-| `oci://ghcr.io/controlplaneio-fluxcd/d2-apps/frontend`      | d2-apps        | staging / production                                       |
+- `latest` for the main branch commits that modify the component.
+- `vX.Y.Z` for the release tags matching the Git tag format `<component>/vX.Y.Z`.
+- `latest-stable` points to the latest artifact tagged as `vX.Y.Z`.
 
-## Onboarding platform components
+A component artifact contains the Kubernetes manifests (Flux resources and Kustomize overlays)
+that define the desired state of the component for the whole fleet of clusters:
+
+```text
+.
+├── base
+│   ├── kustomization.yaml
+│   └── helm-release.yaml
+├── production
+│   ├── kustomization.yaml
+│   └── values-patch.yaml
+└── staging
+    ├── kustomization.yaml
+    └── values-patch.yaml
+```
+
+When Flux Operator reconciles the `ResourceSet` for the components, it configures the components tagged
+as `latest` to be deployed on the staging clusters, and the ones tagged as
+`latest-stable` to be deployed in production.
+
+Rolling back a component in production can be done by moving its `latest-stable` tag to a previous version,
+for example, `flux tag oci://ghcr.io/controlplaneio-fluxcd/d2-apps/frontend:v1.2.3 --tag latest-stable`.
+
+The semver tags are considered immutable, while the `latest-stable` tag act as a pointer to the
+latest release of the component.
+
+## Bootstrap Procedure
+
+The bootstrap procedure is a one-time operation that installs the Flux Operator on the cluster,
+configures the Flux controllers and the delivery of platform components and applications.
+
+After bootstrap, changes to the Flux configuration and version upgrades are done by
+modifying the [FluxInstance](https://github.com/controlplaneio-fluxcd/d2-fleet/blob/main/clusters/staging/flux-system/flux-instance.yaml)
+manifest and letting Flux reconcile the changes, there is no need to run bootstrap
+again nor connect to the cluster.
+
+### GitHub PAT Configuration
+
+It is recommended to create a dedicated GitHub account for the Flux bot. This account will be used
+by the Flux source-controller running on clusters to authenticate with GitHub Container Registry
+to pull the OCI Artifacts.
+
+The Flux bot account must have read access to the `d2-fleet`, `d2-infra` and `d2-apps` repositories,
+and the GitHub Personal Access Token (PAT) should grant read-only access to the GitHub Container Registry
+by selecting the `read:packages` scope.
+
+### Bootstrap a Kubernetes Cluster
+
+For testing purposes, you can create a KinD cluster and bootstrap Flux with the staging configuration
+by running the following commands:
+
+```shell
+export GITHUB_TOKEN=<Flux Bot PAT>
+
+make bootstrap-staging
+```
+
+Another option is to use Terraform or OpenTofu. An example of how to bootstrap a cluster with Terraform
+is available in the [terraform](https://github.com/controlplaneio-fluxcd/d2-fleet/tree/main/terraform) directory.
+
+```shell
+terraform apply \
+  -var oci_token="${GITHUB_TOKEN}" \
+  -var oci_url="oci://ghcr.io/controlplaneio-fluxcd/d2-fleet" \
+  -var oci_tag="latest" \
+  -var oci_path="clusters/staging"
+```
+
+The bootstrap performs the following steps:
+
+- Creates the `flux-system` namespace.
+- Installs the Flux Operator using Helm.
+- Creates a `FluxInstance` pointing to the `oci://ghcr.io/controlplaneio-fluxcd/d2-fleet` artifact.
+- Creates a Kubernetes image pull secret with the GitHub PAT.
+
+After bootstrap, the Flux Operator Helm release and the Flux instance configuration
+are being managed by Flux itself. Any changes to the Flux configuration from now on should be done
+by modifying the manifests in the
+[flux-system](https://github.com/controlplaneio-fluxcd/d2-fleet/tree/main/clusters/staging/flux-system)
+directory.
+
+## Onboarding Platform Components
 
 The platform team is responsible for onboarding the platform components defined as Flux HelmReleases in the
 [d2-infra repository](https://github.com/controlplaneio-fluxcd/d2-infra) and set the dependencies

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,63 @@
+# Bootstrap Flux with Terraform
+
+This example demonstrates how to deploy Flux on a Kubernetes cluster using Terraform
+and the `flux-operator` and `flux-instance` Helm charts.
+
+## Usage
+
+Create a Kubernetes cluster using KinD:
+
+```shell
+kind create cluster --name flux-staging
+```
+
+Install the Flux Operator and deploy the Flux instance on the staging cluster 
+set as the default context in the `~/.kube/config` file:
+
+```shell
+terraform apply \
+  -var oci_token="${GITHUB_TOKEN}" \
+  -var oci_url="oci://ghcr.io/controlplaneio-fluxcd/d2-fleet" \
+  -var oci_tag="latest" \
+  -var oci_path="clusters/staging"
+```
+
+Note that the `GITHUB_TOKEN` env var must be set to a GitHub personal access token.
+The `oci_token` variable is used to create a Kubernetes image pull secret in the
+`flux-system` namespace for Flux to authenticate with the GitHub Container Registry.
+
+Verify the Flux components are running:
+
+```shell
+kubectl -n flux-system get pods
+```
+
+Wait for the bootstrap process to complete and the Flux instance to sync the cluster state:
+
+```shell
+flux get all -A
+```
+
+Verify the Flux instance state:
+
+```shell
+kubectl -n flux-system get fluxreport/flux -o yaml
+```
+
+The output should show the sync status:
+
+```yaml
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxReport
+metadata:
+  name: flux
+  namespace: flux-system
+spec:
+  # Distribution status omitted for brevity
+  sync:
+    id: kustomization/flux-system
+    path: clusters/staging
+    ready: true
+    source: oci://ghcr.io/controlplaneio-fluxcd/d2-fleet
+    status: 'Applied revision: latest@sha256:b66a51......'
+```

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,115 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.27"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.12"
+    }
+  }
+}
+
+// Create the  flux-system namespace.
+resource "kubernetes_namespace" "flux_system" {
+  metadata {
+    name = "flux-system"
+  }
+
+  lifecycle {
+    ignore_changes = [metadata]
+  }
+}
+
+// Create a Kubernetes image pull secret for GHCR.
+resource "kubernetes_secret" "git_auth" {
+  depends_on = [kubernetes_namespace.flux_system]
+
+  metadata {
+    name      = "ghcr-auth"
+    namespace = "flux-system"
+  }
+
+  data = {
+    ".dockerconfigjson" = jsonencode({
+      "auths" : {
+        "ghcr.io" : {
+          username = "flux"
+          password = var.oci_token
+          auth     = base64encode(join(":", ["flux", var.oci_token]))
+        }
+      }
+    })
+  }
+
+  type = "kubernetes.io/dockerconfigjson"
+}
+
+// Install the Flux Operator.
+resource "helm_release" "flux_operator" {
+  depends_on = [kubernetes_namespace.flux_system]
+
+  name       = "flux-operator"
+  namespace  = "flux-system"
+  repository = "oci://ghcr.io/controlplaneio-fluxcd/charts"
+  chart      = "flux-operator"
+  wait       = true
+
+  values = [
+    file("values/operator.yaml")
+  ]
+}
+
+// Configure the Flux instance.
+resource "helm_release" "flux_instance" {
+  depends_on = [helm_release.flux_operator]
+
+  name       = "flux"
+  namespace  = "flux-system"
+  repository = "oci://ghcr.io/controlplaneio-fluxcd/charts"
+  chart      = "flux-instance"
+
+  // Configure the Flux components and kustomize patches.
+  values = [
+    file("values/instance.yaml")
+  ]
+
+  // Configure the Flux distribution.
+  set {
+    name  = "instance.distribution.version"
+    value = var.flux_version
+  }
+  set {
+    name  = "instance.distribution.registry"
+    value = var.flux_registry
+  }
+  set {
+    name  = "instance.distribution.artifact"
+    value = "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest"
+  }
+
+  // Configure Flux sync from GitHub Container Registry.
+  set {
+    name  = "instance.sync.kind"
+    value = "OCIRepository"
+  }
+  set {
+    name  = "instance.sync.url"
+    value = var.oci_url
+  }
+  set {
+    name  = "instance.sync.path"
+    value = var.oci_path
+  }
+  set {
+    name  = "instance.sync.ref"
+    value = var.oci_tag
+  }
+  set {
+    name  = "instance.sync.pullSecret"
+    value = "ghcr-auth"
+  }
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,9 @@
+provider "kubernetes" {
+  config_path = "~/.kube/config"
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = "~/.kube/config"
+  }
+}

--- a/terraform/values/instance.yaml
+++ b/terraform/values/instance.yaml
@@ -1,0 +1,35 @@
+instance:
+  components:
+    - source-controller
+    - kustomize-controller
+    - helm-controller
+    - notification-controller
+  cluster:
+    type: kubernetes
+    multitenant: true
+    tenantDefaultServiceAccount: flux
+    networkPolicy: true
+    domain: "cluster.local"
+  kustomize:
+    patches:
+      - target:
+          kind: Deployment
+          name: "(kustomize-controller|helm-controller)"
+        patch: |
+          - op: add
+            path: /spec/template/spec/containers/0/args/-
+            value: --concurrent=10
+          - op: add
+            path: /spec/template/spec/containers/0/args/-
+            value: --requeue-dependency=10s
+      - target:
+          kind: OCIRepository
+          name: flux-system
+        patch: |
+          - op: add
+            path: /spec/verify
+            value:
+              provider: cosign
+              matchOIDCIdentity:
+              - issuer: ^https://token\.actions\.githubusercontent\.com$
+                subject: ^https://github\.com/controlplaneio-fluxcd/d2-fleet/\.github/workflows/push-artifact\.yaml@refs/heads/main$

--- a/terraform/values/operator.yaml
+++ b/terraform/values/operator.yaml
@@ -1,0 +1,5 @@
+multitenancy:
+  enabled: true
+  defaultServiceAccount: flux-operator
+reporting:
+  interval: 45s

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,36 @@
+variable "oci_token" {
+  description = "GitHub PAT"
+  sensitive   = true
+  type        = string
+  nullable    = false
+}
+
+variable "oci_url" {
+  description = "OCI repository URL"
+  type        = string
+  default = "oci://ghcr.io/controlplaneio-fluxcd/d2-fleet"
+}
+
+variable "oci_path" {
+  description = "Path to the cluster manifests in the OCI artifact"
+  type        = string
+  nullable    = false
+}
+
+variable "oci_tag" {
+  description = "OCI artifact tag"
+  type        = string
+  nullable    = false
+}
+
+variable "flux_version" {
+  description = "Flux version semver range"
+  type        = string
+  default     = "2.x"
+}
+
+variable "flux_registry" {
+  description = "Flux distribution registry"
+  type        = string
+  default     = "ghcr.io/fluxcd"
+}


### PR DESCRIPTION
Add Terraform script as an alternative to bootstrapping clusters using Helm CLI and Make. 