### PR TITLE
Update OCIRepository to v1 (GA)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,6 @@ all: push bootstrap-staging
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-##@ Cluster
-
-cluster-up: ## Creates a Kubernetes KinD cluster and a local registry bind to localhost:5050.
-	./scripts/kind-up.sh
-
-cluster-down: ## Shutdown the Kubernetes KinD cluster and the local registry.
-	./scripts/kind-down.sh
-
 ##@ Artifacts
 
 push: ## Push the Kubernetes manifests to Github Container Registry.

--- a/clusters/prod-eu/flux-system/flux-operator.yaml
+++ b/clusters/prod-eu/flux-system/flux-operator.yaml
@@ -9,7 +9,7 @@ spec:
       kind: CustomResourceDefinition
       name: helmreleases.helm.toolkit.fluxcd.io
   resources:
-    - apiVersion: source.toolkit.fluxcd.io/v1beta2
+    - apiVersion: source.toolkit.fluxcd.io/v1
       kind: OCIRepository
       metadata:
         name: flux-operator

--- a/clusters/prod-us/flux-system/flux-operator.yaml
+++ b/clusters/prod-us/flux-system/flux-operator.yaml
@@ -9,7 +9,7 @@ spec:
       kind: CustomResourceDefinition
       name: helmreleases.helm.toolkit.fluxcd.io
   resources:
-    - apiVersion: source.toolkit.fluxcd.io/v1beta2
+    - apiVersion: source.toolkit.fluxcd.io/v1
       kind: OCIRepository
       metadata:
         name: flux-operator

--- a/clusters/staging/flux-system/flux-operator.yaml
+++ b/clusters/staging/flux-system/flux-operator.yaml
@@ -9,7 +9,7 @@ spec:
       kind: CustomResourceDefinition
       name: helmreleases.helm.toolkit.fluxcd.io
   resources:
-    - apiVersion: source.toolkit.fluxcd.io/v1beta2
+    - apiVersion: source.toolkit.fluxcd.io/v1
       kind: OCIRepository
       metadata:
         name: flux-operator

--- a/clusters/update/flux-system/flux-operator.yaml
+++ b/clusters/update/flux-system/flux-operator.yaml
@@ -9,7 +9,7 @@ spec:
       kind: CustomResourceDefinition
       name: helmreleases.helm.toolkit.fluxcd.io
   resources:
-    - apiVersion: source.toolkit.fluxcd.io/v1beta2
+    - apiVersion: source.toolkit.fluxcd.io/v1
       kind: OCIRepository
       metadata:
         name: flux-operator

--- a/tenants/apps.yaml
+++ b/tenants/apps.yaml
@@ -66,7 +66,7 @@ spec:
         - kind: ServiceAccount
           name: flux
           namespace: << inputs.tenant >>
-    - apiVersion: source.toolkit.fluxcd.io/v1beta2
+    - apiVersion: source.toolkit.fluxcd.io/v1
       kind: OCIRepository
       metadata:
         name: apps

--- a/tenants/infra.yaml
+++ b/tenants/infra.yaml
@@ -63,7 +63,7 @@ spec:
         - kind: ServiceAccount
           name: flux
           namespace: << inputs.tenant >>
-    - apiVersion: source.toolkit.fluxcd.io/v1beta2
+    - apiVersion: source.toolkit.fluxcd.io/v1
       kind: OCIRepository
       metadata:
         name: infra

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.27"
+      version = ">= 2.37"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.12"
+      version = ">= 3.0"
     }
   }
 }
@@ -39,7 +39,7 @@ resource "kubernetes_secret" "git_auth" {
         "ghcr.io" : {
           username = "flux"
           password = var.oci_token
-          auth     = base64encode(join(":", ["flux", var.oci_token]))
+          auth = base64encode(join(":", ["flux", var.oci_token]))
         }
       }
     })
@@ -70,46 +70,46 @@ resource "helm_release" "flux_instance" {
   name       = "flux"
   namespace  = "flux-system"
   repository = "oci://ghcr.io/controlplaneio-fluxcd/charts"
-  chart      = "flux-instance"
+  chart = "flux-instance"
 
   // Configure the Flux components and kustomize patches.
   values = [
     file("values/instance.yaml")
   ]
 
-  // Configure the Flux distribution.
-  set {
-    name  = "instance.distribution.version"
-    value = var.flux_version
-  }
-  set {
-    name  = "instance.distribution.registry"
-    value = var.flux_registry
-  }
-  set {
-    name  = "instance.distribution.artifact"
-    value = "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest"
-  }
-
-  // Configure Flux sync from GitHub Container Registry.
-  set {
-    name  = "instance.sync.kind"
-    value = "OCIRepository"
-  }
-  set {
-    name  = "instance.sync.url"
-    value = var.oci_url
-  }
-  set {
-    name  = "instance.sync.path"
-    value = var.oci_path
-  }
-  set {
-    name  = "instance.sync.ref"
-    value = var.oci_tag
-  }
-  set {
-    name  = "instance.sync.pullSecret"
-    value = "ghcr-auth"
-  }
+  // Configure the Flux distribution and sync from GitHub Container Registry.
+  set = [
+    {
+      name  = "instance.distribution.version"
+      value = var.flux_version
+    },
+    {
+      name  = "instance.distribution.registry"
+      value = var.flux_registry
+    },
+    {
+      name  = "instance.distribution.artifact"
+      value = "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest"
+    },
+    {
+      name  = "instance.sync.kind"
+      value = "OCIRepository"
+    },
+    {
+      name  = "instance.sync.url"
+      value = var.oci_url
+    },
+    {
+      name  = "instance.sync.path"
+      value = var.oci_path
+    },
+    {
+      name  = "instance.sync.ref"
+      value = var.oci_tag
+    },
+    {
+      name  = "instance.sync.pullSecret"
+      value = "ghcr-auth"
+    },
+  ]
 }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -3,7 +3,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     config_path = "~/.kube/config"
   }
 }


### PR DESCRIPTION
Part of: #9 
Fix: #8 

In addition, the Terraform Helm provider has been updated to v3 and breaking changes addressed.