### PR TITLE
terraform: Enable FluxInstance healthcheck

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -111,5 +111,10 @@ resource "helm_release" "flux_instance" {
       name  = "instance.sync.pullSecret"
       value = "ghcr-auth"
     },
+    {
+      name  = "healthcheck.enabled"
+      value = "true"
+      type  = "auto"
+    },
   ]
 }


### PR DESCRIPTION
Make `terraform apply`wait for the Flux instance to become ready