### PR TITLE
Enable force upgrade of Flux Operator

### DIFF
--- a/clusters/prod-eu/flux-system/flux-instance.yaml
+++ b/clusters/prod-eu/flux-system/flux-instance.yaml
@@ -15,6 +15,7 @@ spec:
     - notification-controller
   cluster:
     type: kubernetes
+    size: medium
     multitenant: true
     tenantDefaultServiceAccount: flux
     networkPolicy: true
@@ -27,16 +28,6 @@ spec:
     pullSecret: "ghcr-auth"
   kustomize:
     patches:
-      - target:
-          kind: Deployment
-          name: "(kustomize-controller|helm-controller)"
-        patch: |
-          - op: add
-            path: /spec/template/spec/containers/0/args/-
-            value: --concurrent=10
-          - op: add
-            path: /spec/template/spec/containers/0/args/-
-            value: --requeue-dependency=10s
       - target:
           kind: OCIRepository
           name: flux-system

--- a/clusters/prod-eu/flux-system/flux-operator.yaml
+++ b/clusters/prod-eu/flux-system/flux-operator.yaml
@@ -36,6 +36,13 @@ spec:
         chartRef:
           kind: OCIRepository
           name: flux-operator
+        install:
+          strategy: RetryOnFailure
+          retryInterval: 3m
+        upgrade:
+          force: true
+          strategy: RetryOnFailure
+          retryInterval: 3m
         values:
           multitenancy:
             enabled: true

--- a/clusters/prod-us/flux-system/flux-instance.yaml
+++ b/clusters/prod-us/flux-system/flux-instance.yaml
@@ -15,6 +15,7 @@ spec:
     - notification-controller
   cluster:
     type: kubernetes
+    size: medium
     multitenant: true
     tenantDefaultServiceAccount: flux
     networkPolicy: true
@@ -27,16 +28,6 @@ spec:
     pullSecret: "ghcr-auth"
   kustomize:
     patches:
-      - target:
-          kind: Deployment
-          name: "(kustomize-controller|helm-controller)"
-        patch: |
-          - op: add
-            path: /spec/template/spec/containers/0/args/-
-            value: --concurrent=10
-          - op: add
-            path: /spec/template/spec/containers/0/args/-
-            value: --requeue-dependency=10s
       - target:
           kind: OCIRepository
           name: flux-system

--- a/clusters/prod-us/flux-system/flux-operator.yaml
+++ b/clusters/prod-us/flux-system/flux-operator.yaml
@@ -36,6 +36,13 @@ spec:
         chartRef:
           kind: OCIRepository
           name: flux-operator
+        install:
+          strategy: RetryOnFailure
+          retryInterval: 3m
+        upgrade:
+          force: true
+          strategy: RetryOnFailure
+          retryInterval: 3m
         values:
           multitenancy:
             enabled: true

--- a/clusters/staging/flux-system/flux-instance.yaml
+++ b/clusters/staging/flux-system/flux-instance.yaml
@@ -15,6 +15,7 @@ spec:
     - notification-controller
   cluster:
     type: kubernetes
+    size: medium
     multitenant: true
     tenantDefaultServiceAccount: flux
     networkPolicy: true
@@ -27,16 +28,6 @@ spec:
     pullSecret: "ghcr-auth"
   kustomize:
     patches:
-      - target:
-          kind: Deployment
-          name: "(kustomize-controller|helm-controller)"
-        patch: |
-          - op: add
-            path: /spec/template/spec/containers/0/args/-
-            value: --concurrent=10
-          - op: add
-            path: /spec/template/spec/containers/0/args/-
-            value: --requeue-dependency=10s
       - target:
           kind: OCIRepository
           name: flux-system

--- a/clusters/staging/flux-system/flux-operator.yaml
+++ b/clusters/staging/flux-system/flux-operator.yaml
@@ -36,6 +36,13 @@ spec:
         chartRef:
           kind: OCIRepository
           name: flux-operator
+        install:
+          strategy: RetryOnFailure
+          retryInterval: 3m
+        upgrade:
+          force: true
+          strategy: RetryOnFailure
+          retryInterval: 3m
         values:
           multitenancy:
             enabled: true

--- a/clusters/update/flux-system/flux-instance.yaml
+++ b/clusters/update/flux-system/flux-instance.yaml
@@ -17,6 +17,7 @@ spec:
     - image-automation-controller
   cluster:
     type: kubernetes
+    size: medium
     multitenant: true
     tenantDefaultServiceAccount: flux
     networkPolicy: true

--- a/clusters/update/flux-system/flux-operator.yaml
+++ b/clusters/update/flux-system/flux-operator.yaml
@@ -36,6 +36,13 @@ spec:
         chartRef:
           kind: OCIRepository
           name: flux-operator
+        install:
+          strategy: RetryOnFailure
+          retryInterval: 3m
+        upgrade:
+          force: true
+          strategy: RetryOnFailure
+          retryInterval: 3m
         values:
           multitenancy:
             enabled: true


### PR DESCRIPTION
Use Flux 2.7 RetryOnFailure strategy and enable force upgrade of Flux Operator