### PR TITLE
Add source-watcher to components

### DIFF
--- a/.github/workflows/e2e-production.yaml
+++ b/.github/workflows/e2e-production.yaml
@@ -5,6 +5,9 @@ on:
   push:
     tags: [ '*' ]
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-staging.yaml
+++ b/.github/workflows/e2e-staging.yaml
@@ -2,8 +2,12 @@ name: e2e-staging
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches: [ 'main' ]
+
+permissions:
+  contents: read
 
 jobs:
   e2e:

--- a/.github/workflows/e2e-update.yaml
+++ b/.github/workflows/e2e-update.yaml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: 0 8 * * 1
 
+permissions:
+  contents: read
+
 jobs:
   image-update:
     runs-on: ubuntu-latest

--- a/clusters/prod-eu/flux-system/flux-instance.yaml
+++ b/clusters/prod-eu/flux-system/flux-instance.yaml
@@ -10,6 +10,7 @@ spec:
     artifact: "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest"
   components:
     - source-controller
+    - source-watcher
     - kustomize-controller
     - helm-controller
     - notification-controller

--- a/clusters/prod-us/flux-system/flux-instance.yaml
+++ b/clusters/prod-us/flux-system/flux-instance.yaml
@@ -10,6 +10,7 @@ spec:
     artifact: "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest"
   components:
     - source-controller
+    - source-watcher
     - kustomize-controller
     - helm-controller
     - notification-controller

--- a/clusters/staging/flux-system/flux-instance.yaml
+++ b/clusters/staging/flux-system/flux-instance.yaml
@@ -10,6 +10,7 @@ spec:
     artifact: "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest"
   components:
     - source-controller
+    - source-watcher
     - kustomize-controller
     - helm-controller
     - notification-controller

--- a/clusters/update/flux-system/flux-instance.yaml
+++ b/clusters/update/flux-system/flux-instance.yaml
@@ -7,12 +7,9 @@ spec:
   distribution:
     version: "2.x"
     registry: "ghcr.io/fluxcd"
-    artifact: "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest"
   components:
     - source-controller
     - kustomize-controller
-    - helm-controller
-    - notification-controller
     - image-reflector-controller
     - image-automation-controller
   cluster:


### PR DESCRIPTION
Add source-watcher to prod clusters and remove unused components from the update cluster.