### PR TITLE
Make verify identity regexes more readable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ go.work.sum
 *.tfstate.*
 .terraform.lock.hcl
 .terraformrc
+
+# Editor and IDE paraphernalia
+.idea
+*.iml

--- a/clusters/prod-eu/flux-system/flux-operator.yaml
+++ b/clusters/prod-eu/flux-system/flux-operator.yaml
@@ -22,8 +22,8 @@ spec:
         verify:
           provider: cosign
           matchOIDCIdentity:
-          - issuer: ^https://token\.actions\.githubusercontent\.com$
-            subject: ^https://github\.com/controlplaneio-fluxcd/charts/\.github/workflows/release\.yml@refs/tags/v\d+\.\d+\.\d+$
+          - issuer: ^<< "https://token.actions.githubusercontent.com" | regexQuoteMeta >>$
+            subject: ^<< "https://github.com/controlplaneio-fluxcd/charts/.github/workflows/release.yml@refs/tags/v" | regexQuoteMeta >>\d+\.\d+\.\d+$
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       metadata:

--- a/clusters/prod-us/flux-system/flux-operator.yaml
+++ b/clusters/prod-us/flux-system/flux-operator.yaml
@@ -22,8 +22,8 @@ spec:
         verify:
           provider: cosign
           matchOIDCIdentity:
-          - issuer: ^https://token\.actions\.githubusercontent\.com$
-            subject: ^https://github\.com/controlplaneio-fluxcd/charts/\.github/workflows/release\.yml@refs/tags/v\d+\.\d+\.\d+$
+          - issuer: ^<< "https://token.actions.githubusercontent.com" | regexQuoteMeta >>$
+            subject: ^<< "https://github.com/controlplaneio-fluxcd/charts/.github/workflows/release.yml@refs/tags/v" | regexQuoteMeta >>\d+\.\d+\.\d+$
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       metadata:

--- a/clusters/staging/flux-system/flux-operator.yaml
+++ b/clusters/staging/flux-system/flux-operator.yaml
@@ -22,8 +22,8 @@ spec:
         verify:
           provider: cosign
           matchOIDCIdentity:
-          - issuer: ^https://token\.actions\.githubusercontent\.com$
-            subject: ^https://github\.com/controlplaneio-fluxcd/charts/\.github/workflows/release\.yml@refs/tags/v\d+\.\d+\.\d+$
+          - issuer: ^<< "https://token.actions.githubusercontent.com" | regexQuoteMeta >>$
+            subject: ^<< "https://github.com/controlplaneio-fluxcd/charts/.github/workflows/release.yml@refs/tags/v" | regexQuoteMeta >>\d+\.\d+\.\d+$
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       metadata:

--- a/clusters/update/flux-system/flux-operator.yaml
+++ b/clusters/update/flux-system/flux-operator.yaml
@@ -22,8 +22,8 @@ spec:
         verify:
           provider: cosign
           matchOIDCIdentity:
-          - issuer: ^https://token\.actions\.githubusercontent\.com$
-            subject: ^https://github\.com/controlplaneio-fluxcd/charts/\.github/workflows/release\.yml@refs/tags/v\d+\.\d+\.\d+$
+          - issuer: ^<< "https://token.actions.githubusercontent.com" | regexQuoteMeta >>$
+            subject: ^<< "https://github.com/controlplaneio-fluxcd/charts/.github/workflows/release.yml@refs/tags/v" | regexQuoteMeta >>\d+\.\d+\.\d+$
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       metadata:

--- a/tenants/apps.yaml
+++ b/tenants/apps.yaml
@@ -82,8 +82,8 @@ spec:
         verify:
           provider: cosign
           matchOIDCIdentity:
-          - issuer: ^https://token\.actions\.githubusercontent\.com$
-            subject: ^https://github\.com/controlplaneio-fluxcd/d2-apps/\.github/workflows/<< inputs.artifactSubjectWorkflow >>\.yaml@<< inputs.artifactSubjectGitRef >>$
+          - issuer: ^<< "https://token.actions.githubusercontent.com" | regexQuoteMeta >>$
+            subject: ^<< printf "https://github.com/controlplaneio-fluxcd/d2-apps/.github/workflows/%s.yaml@%s" inputs.artifactSubjectWorkflow inputs.artifactSubjectGitRef | regexQuoteMeta >>$
     - apiVersion: kustomize.toolkit.fluxcd.io/v1
       kind: Kustomization
       metadata:

--- a/tenants/infra.yaml
+++ b/tenants/infra.yaml
@@ -79,8 +79,8 @@ spec:
         verify:
           provider: cosign
           matchOIDCIdentity:
-          - issuer: ^https://token\.actions\.githubusercontent\.com$
-            subject: ^https://github\.com/controlplaneio-fluxcd/d2-infra/\.github/workflows/<< inputs.artifactSubjectWorkflow >>\.yaml@<< inputs.artifactSubjectGitRef >>$
+          - issuer: ^<< "https://token.actions.githubusercontent.com" | regexQuoteMeta >>$
+            subject: ^<< printf "https://github.com/controlplaneio-fluxcd/d2-infra/.github/workflows/%s.yaml@%s" inputs.artifactSubjectWorkflow inputs.artifactSubjectGitRef | regexQuoteMeta >>$
     - apiVersion: kustomize.toolkit.fluxcd.io/v1
       kind: Kustomization
       metadata:


### PR DESCRIPTION
When using this project as a template for our own Flux D2 infra project, I spent quite some time "decoding" the escaped verify identity regexes. 😅 I wonder if more parts of it should be templated to better support the copy-modify process I just used today. But let's start making the regex templates more readable, at least in my opinion.

Feel free to just close this PR if you don't like the approach taken. With the proposed change, the expressions become a bit longer and will probably require some more clock cycles, so there are arguments for escaping the regexes before committing them to Git.